### PR TITLE
This commit fixes a fatal error in the `seed.php` script.

### DIFF
--- a/seed.php
+++ b/seed.php
@@ -47,7 +47,7 @@ try {
     foreach ($catalogs as $tableName => $data) {
         echo "Sembrando '$tableName'...\n";
         // Use "INSERT IGNORE" to avoid errors if the key already exists.
-        $stmt = $db->dbh->prepare("INSERT IGNORE INTO $tableName (`key`, `value`) VALUES (:key, :value)");
+        $stmt = $db->getDbh()->prepare("INSERT IGNORE INTO $tableName (`key`, `value`) VALUES (:key, :value)");
         foreach ($data as $key => $value) {
             $stmt->execute(['key' => $key, 'value' => $value]);
         }
@@ -55,7 +55,7 @@ try {
     }
 
     // Seed the new SAT units table
-    seed_sat_units($db->dbh);
+    seed_sat_units($db->getDbh());
 
     echo "\n¡Siembra de catálogos completada con éxito!\n";
 

--- a/src/lib/Database.php
+++ b/src/lib/Database.php
@@ -82,5 +82,10 @@ class Database {
     public function lastInsertId() {
         return $this->dbh->lastInsertId();
     }
+
+    // Get the PDO instance
+    public function getDbh() {
+        return $this->dbh;
+    }
 }
 ?>


### PR DESCRIPTION
The script was attempting to access the private property `$dbh` directly from the `Database` class instance, causing a "Cannot access private property" error.

- A public getter method `getDbh()` has been added to the `Database` class to provide safe access to the PDO handler.
- The `seed.php` script has been updated to use this new method, resolving the error.